### PR TITLE
deploy_llm.sh を実行するための IAMRole を kendra-docs-index.yaml で作成するように反映

### DIFF
--- a/kendra/kendra-docs-index.yaml
+++ b/kendra/kendra-docs-index.yaml
@@ -203,7 +203,33 @@ Resources:
       - KendraDocsDS
     Properties:
       ServiceToken: !GetAtt DataSourceSyncLambda.Arn
-    
+
+# Create IAM Role and Instance Profile
+  RagRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - ec2.amazonaws.com
+                - cloud9.amazonaws.com
+                - sagemaker.amazonaws.com
+            Action:
+              - 'sts:AssumeRole'
+      Path: /
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/AdministratorAccess
+  InstanceProfile1:
+    Type: AWS::IAM::InstanceProfile
+    Properties:
+      InstanceProfileName: !Ref RagRole
+      Path: /
+      Roles:
+        - !Ref RagRole
+
 Outputs:
   KendraIndexID:
     Value: !GetAtt DocsKendraIndex.Id


### PR DESCRIPTION
deploy_llm.sh を実行するためにはIAM ロールを別途用意して SageMaker との信頼関係を結ぶ必要がありました。しかし、本バージョンの kendra-docs-index.yaml を利用することで SageMaker, Cloud9 との信頼関係を結んだ AdministratorAccess 権限の付与された IAM ロールも合わせて自動作成できるため、アプリケーション構築手順を簡略化できます。