### PR TITLE
Upgrade deprecated runtime nodejs14.x

### DIFF
--- a/amplify/backend/api/fargate/fargate-cloudformation-template.json
+++ b/amplify/backend/api/fargate/fargate-cloudformation-template.json
@@ -1779,7 +1779,7 @@
           }
         },
         "Handler": "framework.onEvent",
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs16.x",
         "Timeout": 900
       },
       "DependsOn": [
@@ -1921,7 +1921,7 @@
           }
         },
         "Handler": "framework.isComplete",
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs16.x",
         "Timeout": 900
       },
       "DependsOn": [
@@ -2063,7 +2063,7 @@
           }
         },
         "Handler": "framework.onTimeout",
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs16.x",
         "Timeout": 900
       },
       "DependsOn": [


### PR DESCRIPTION
CloudFormation templates in jp-rag-sample have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs14.x). The affected templates have been updated to a supported runtime (nodejs16.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.